### PR TITLE
PDF build and release automation

### DIFF
--- a/.github/workflows/build_and_upload_pdf.yml
+++ b/.github/workflows/build_and_upload_pdf.yml
@@ -1,0 +1,53 @@
+name: Build and upload PDF
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*.*.*
+  pull_request:
+
+jobs:
+  pdf:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: main.tex
+          extra_system_packages: inkscape
+          latexmk_shell_escape: true
+
+      - name: Get PDF version
+        id: get-version
+        run: |
+          if [ ${{ github.ref_type }} = tag ]; then
+            version=${{ github.ref_name }}
+          elif [ ${{ github.ref_type }} = branch ]; then
+            version=${GITHUB_SHA:0:7}
+          else
+            echo 'Unknown github.ref_name: ${{ github.ref_type }}'
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Rename PDF
+        run: mv main.pdf 'indigo-paper-${{ steps.get-version.outputs.version }}.pdf'
+
+      - name: Upload PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: pdf
+          path: indigo-paper-${{ steps.get-version.outputs.version }}.pdf
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        if: github.ref_type == 'tag'
+        with:
+          files: indigo-paper-${{ steps.get-version.outputs.version }}.pdf
+          generate_release_notes: true


### PR DESCRIPTION
- Build PDF and auto release when a commit is tagged e.g. `v1.0.3`. Released PDF's name would be `indigo-paper-v1.0.3.pdf`.
- Build PDF on PRs.
	- For a commit hash `3be9cd9e8cbb63cbd6d71a762f55ecfcd8918e6d` the PDF's name would be `indigo-paper-3be9cd9.pdf`.
	- Looked into having GitHub Actions also comment a URL of the built PDF artifact. While the URL can be constructed, bot commenting would fail if the PR is opened from a forked repo, so I left this out.
	- As it is, the ZIP file with the generated PDF can be manually navigated to, which is not ideal, but better than it was.